### PR TITLE
Fix file handle leak in ClaudeCLIBackend

### DIFF
--- a/src/agent_framework/llm/claude_cli_backend.py
+++ b/src/agent_framework/llm/claude_cli_backend.py
@@ -261,20 +261,23 @@ class ClaudeCLIBackend(LLMBackend):
         if task_id:
             self.logs_dir.mkdir(parents=True, exist_ok=True)
             log_file_path = self.logs_dir / f"claude-cli-{task_id}.log"
-            log_file = open(log_file_path, "w")
-            log_file.write(f"=== Claude CLI Task: {task_id} ===\n")
-            log_file.write(f"Model: {model}\n")
-            log_file.write(f"Working Directory: {request.working_dir or 'current directory'}\n")
-            log_file.write(f"Started: {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
-            log_file.write(f"Timeout: {timeout}s\n")
-            log_file.write("=" * 50 + "\n\n")
-            log_file.flush()
-            logger.info(f"Streaming Claude CLI output to {log_file_path}")
 
         try:
-            # Prepare clean environment (exclude problematic beta flag)
+            # Open file inside try block so finally always closes it
+            if log_file_path:
+                log_file = open(log_file_path, "w")
+                log_file.write(f"=== Claude CLI Task: {task_id} ===\n")
+                log_file.write(f"Model: {model}\n")
+                log_file.write(f"Working Directory: {request.working_dir or 'current directory'}\n")
+                log_file.write(f"Started: {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+                log_file.write(f"Timeout: {timeout}s\n")
+                log_file.write("=" * 50 + "\n\n")
+                log_file.flush()
+                logger.info(f"Streaming Claude CLI output to {log_file_path}")
+
+            # Prepare clean environment (disable experimental betas for AWS Bedrock compatibility)
             env = os.environ.copy()
-            env.pop('CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS', None)
+            env['CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS'] = '1'
             env.update(self.proxy_env)
             if task_id:
                 env['AGENT_TASK_ID'] = task_id


### PR DESCRIPTION
## Summary
- Move log file `open()` inside the `try` block so the `finally` block always closes it, preventing handle leaks in long-running agent processes
- Explicitly set `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` for AWS Bedrock compatibility

## Test plan
- [ ] Verify Claude CLI backend streams output correctly with task logging
- [ ] Verify no file handle leaks under error conditions
- [ ] Verify Bedrock compatibility with disabled experimental betas

🤖 Generated with [Claude Code](https://claude.com/claude-code)