### PR TITLE
feat: Add guided escalation with structured reports and human guidance

### DIFF
--- a/docs/guided_escalation.md
+++ b/docs/guided_escalation.md
@@ -1,0 +1,214 @@
+# Guided Escalation
+
+## Overview
+
+The guided escalation feature provides structured escalation reports with detailed diagnostics when tasks fail after multiple retry attempts. It allows humans to inject targeted guidance into failed tasks and retry them with additional context.
+
+## Problem Statement
+
+Previously, when tasks failed and escalated:
+- Escalations were opaque - just basic error messages
+- Humans had to dig through logs to understand what happened
+- No structured way to provide guidance for retry
+- Difficult to identify failure patterns and root causes
+
+## Solution
+
+The guided escalation feature provides:
+
+1. **Structured Escalation Reports** - Detailed failure analysis with:
+   - Complete attempt history
+   - Root cause hypothesis
+   - Suggested interventions
+   - Failure pattern detection
+
+2. **Human Guidance Injection** - CLI command to inject expert guidance:
+   ```bash
+   agent guide <task-id> --hint "Your guidance here"
+   ```
+
+3. **Intelligent Retry** - Failed tasks retry with:
+   - Human guidance injected into LLM prompt
+   - Previous failure context
+   - Categorized error history
+
+## Architecture
+
+### Models
+
+#### `RetryAttempt`
+Records each retry attempt with:
+- `attempt_number`: Sequential attempt counter
+- `timestamp`: When the attempt occurred
+- `error_message`: Full error message
+- `agent_id`: Which agent made the attempt
+- `error_type`: Categorized error (network, authentication, validation, etc.)
+- `context_snapshot`: Relevant context at time of failure
+
+#### `EscalationReport`
+Structured diagnostic report with:
+- `task_id`: Original failed task ID
+- `original_title`: Task title
+- `total_attempts`: Number of retry attempts
+- `attempt_history`: List of all `RetryAttempt` records
+- `root_cause_hypothesis`: AI-generated hypothesis about failure cause
+- `suggested_interventions`: List of actionable suggestions
+- `failure_pattern`: Pattern classification (consistent, intermittent, varied)
+- `human_guidance`: Optional human-provided guidance for retry
+
+### Error Categorization
+
+Errors are automatically categorized into:
+- **network**: Connection issues, timeouts, DNS failures
+- **authentication**: Auth failures, permission denied, 401/403
+- **validation**: Schema errors, type errors, invalid input
+- **resource**: Memory issues, disk full, resource exhaustion
+- **logic**: Null references, index errors, assertions
+- **unknown**: Uncategorized errors
+
+### Failure Pattern Detection
+
+The system detects patterns across retry attempts:
+- **consistent**: Same error type across all attempts
+- **intermittent_network**: Primarily network failures
+- **varied**: Different error types across attempts
+- **single_failure**: Only one attempt before escalation
+
+## Usage
+
+### CLI Commands
+
+#### View Failed Tasks
+```bash
+agent retry --all  # List all failed tasks
+```
+
+#### Inject Human Guidance
+```bash
+agent guide task-12345 --hint "Use backup API endpoint: https://backup.api.com"
+agent guide escalation-67890 --hint "Authentication header changed to X-API-Key"
+```
+
+The `guide` command:
+1. Finds the failed task
+2. Shows current escalation report (if available)
+3. Injects your guidance into the task
+4. Resets retry count
+5. Re-queues the task with guidance
+
+### Escalation Report Structure
+
+When a task escalates, the report includes:
+
+```markdown
+## Root Cause Analysis
+**Failure Pattern**: consistent
+**Hypothesis**: Consistent network errors across all attempts suggest...
+
+## Attempt History (3 attempts)
+- **Attempt 1** (2026-02-14 14:30:00)
+  Agent: engineer, Type: network
+  Error: Connection refused: API endpoint not reachable
+
+- **Attempt 2** (2026-02-14 14:31:00)
+  Agent: engineer, Type: network
+  Error: Connection timeout after 30s
+
+- **Attempt 3** (2026-02-14 14:32:00)
+  Agent: engineer, Type: network
+  Error: Network unreachable
+
+## Suggested Interventions
+1. Check network connectivity and firewall rules
+2. Verify API endpoints are accessible
+3. Review rate limiting and retry backoff settings
+4. Consider increasing timeout values
+
+## Next Steps
+Use `agent guide task-12345 --hint "<your guidance>"` to inject guidance and retry.
+```
+
+## Integration with Agent Processing
+
+### Prompt Injection
+
+When a task has human guidance, it's automatically injected into the LLM prompt:
+
+```
+## CRITICAL: Human Guidance Provided
+
+A human expert has reviewed this task and provided the following guidance:
+
+<your guidance here>
+
+Please carefully consider this guidance when approaching the task.
+
+## Previous Failure Context
+
+<root cause hypothesis>
+
+Suggested interventions:
+1. <intervention 1>
+2. <intervention 2>
+...
+```
+
+### Retry Attempt Tracking
+
+Every time a task fails, the system records:
+- Error message and type
+- Agent that attempted it
+- Timestamp
+- Context snapshot
+
+This history is preserved through escalation and used for pattern analysis.
+
+## Example Workflow
+
+1. **Task fails after 5 retries** with network errors
+2. **Escalation created** with structured report
+3. **Architect reviews** escalation report
+4. **Architect runs**: `agent guide task-123 --hint "Use VPN endpoint: https://vpn.internal.api.com"`
+5. **Task re-queued** with guidance injected
+6. **Engineer agent receives** prompt with human guidance
+7. **Task succeeds** using the VPN endpoint
+
+## Benefits
+
+1. **Transparency**: Clear visibility into what failed and why
+2. **Efficiency**: Targeted guidance instead of generic retries
+3. **Learning**: Pattern detection helps identify systemic issues
+4. **Collaboration**: Structured way for humans to assist agents
+5. **Debugging**: Complete history for post-mortem analysis
+
+## Configuration
+
+No additional configuration required. The feature is automatically enabled when:
+- Task retry count is tracked
+- Escalations are created
+- Agent processes tasks
+
+## Testing
+
+Comprehensive test coverage includes:
+- Escalation report generation
+- Error categorization
+- Failure pattern detection
+- Human guidance injection
+- Attempt history preservation
+- Description formatting
+
+Run tests:
+```bash
+pytest tests/unit/test_guided_escalation.py
+pytest tests/unit/test_escalation.py  # Verify backward compatibility
+```
+
+## Future Enhancements
+
+Potential improvements:
+- Machine learning for root cause prediction
+- Automatic similarity detection across failed tasks
+- Guidance suggestion from past successful retries
+- Integration with monitoring/alerting systems
+- Batch guidance application to similar failures

--- a/src/agent_framework/safeguards/escalation.py
+++ b/src/agent_framework/safeguards/escalation.py
@@ -1,9 +1,11 @@
 """Escalation handler for failed tasks (ported from Bash system)."""
 
+import re
 import time
 from datetime import datetime
+from typing import List, Optional
 
-from ..core.task import Task, TaskStatus, TaskType
+from ..core.task import Task, TaskStatus, TaskType, EscalationReport, RetryAttempt
 from ..utils.type_helpers import get_type_str
 
 
@@ -22,6 +24,43 @@ class EscalationHandler:
     def __init__(self, escalation_queue: str = "architect", enable_error_truncation: bool = False):
         self.escalation_queue = escalation_queue
         self.enable_error_truncation = enable_error_truncation
+
+        # Error pattern categorization
+        self._error_patterns = {
+            "network": [
+                r"connection.*refused",
+                r"timeout",
+                r"network.*unreachable",
+                r"dns.*fail",
+                r"could not resolve host",
+            ],
+            "authentication": [
+                r"unauthorized",
+                r"authentication.*fail",
+                r"invalid.*credential",
+                r"permission.*denied",
+                r"403|401",
+            ],
+            "validation": [
+                r"validation.*error",
+                r"invalid.*input",
+                r"schema.*mismatch",
+                r"type.*error",
+                r"missing required",
+            ],
+            "resource": [
+                r"out of memory",
+                r"disk.*full",
+                r"too many.*open files",
+                r"resource.*exhausted",
+            ],
+            "logic": [
+                r"null.*reference",
+                r"index.*out of.*range",
+                r"assertion.*fail",
+                r"unexpected.*state",
+            ],
+        }
 
     def truncate_error(self, error: str, max_lines: int = 35) -> str:
         """
@@ -85,6 +124,131 @@ class EscalationHandler:
 
         return '\n'.join(result)
 
+    def _categorize_error(self, error_message: str) -> Optional[str]:
+        """Categorize error message by pattern matching."""
+        error_lower = error_message.lower()
+        for category, patterns in self._error_patterns.items():
+            for pattern in patterns:
+                if re.search(pattern, error_lower):
+                    return category
+        return "unknown"
+
+    def _analyze_failure_pattern(self, attempts: List[RetryAttempt]) -> str:
+        """Analyze retry attempts to determine failure pattern."""
+        if not attempts:
+            return "single_failure"
+
+        error_types = [a.error_type for a in attempts if a.error_type]
+        if not error_types:
+            return "unknown_pattern"
+
+        # All same error type = consistent failure
+        if len(set(error_types)) == 1:
+            return "consistent"
+
+        # Multiple error types = intermittent or degrading
+        # Check if errors are becoming more severe
+        network_count = error_types.count("network")
+        if network_count > len(error_types) / 2:
+            return "intermittent_network"
+
+        return "varied"
+
+    def _generate_root_cause_hypothesis(self, failed_task: Task) -> str:
+        """Generate hypothesis about root cause based on retry history."""
+        if not failed_task.retry_attempts:
+            return "Task failed without retry attempts recorded. Error may be immediate or critical."
+
+        pattern = self._analyze_failure_pattern(failed_task.retry_attempts)
+        error_types = [a.error_type for a in failed_task.retry_attempts if a.error_type]
+        most_common = max(set(error_types), key=error_types.count) if error_types else "unknown"
+
+        hypotheses = {
+            "consistent": f"Consistent {most_common} errors across all attempts suggest a fundamental issue that won't resolve with retries.",
+            "intermittent_network": "Intermittent network failures suggest infrastructure or connectivity issues rather than code problems.",
+            "varied": "Different error types across attempts suggest environmental instability or race conditions.",
+            "single_failure": "Single catastrophic failure suggests immediate blocker or invalid configuration.",
+        }
+
+        base = hypotheses.get(pattern, "Unable to determine clear pattern from retry history.")
+
+        # Add context from last error
+        if failed_task.last_error:
+            last_attempt = failed_task.retry_attempts[-1] if failed_task.retry_attempts else None
+            if last_attempt and last_attempt.error_type:
+                base += f" Last failure type: {last_attempt.error_type}."
+
+        return base
+
+    def _generate_suggested_interventions(self, failed_task: Task) -> List[str]:
+        """Generate actionable suggestions based on failure analysis."""
+        suggestions = []
+        error_types = [a.error_type for a in failed_task.retry_attempts if a.error_type]
+
+        if not error_types:
+            suggestions.append("Review task logs to identify failure type")
+            suggestions.append("Check task configuration and dependencies")
+            return suggestions
+
+        most_common = max(set(error_types), key=error_types.count)
+
+        intervention_map = {
+            "network": [
+                "Check network connectivity and firewall rules",
+                "Verify API endpoints are accessible",
+                "Review rate limiting and retry backoff settings",
+                "Consider increasing timeout values",
+            ],
+            "authentication": [
+                "Verify credentials are valid and not expired",
+                "Check token refresh mechanisms",
+                "Review permission levels for required operations",
+                "Validate API keys and secrets configuration",
+            ],
+            "validation": [
+                "Review input data format and schema",
+                "Check for recent API or contract changes",
+                "Validate all required fields are populated",
+                "Review type conversions and serialization",
+            ],
+            "resource": [
+                "Check available system resources (memory, disk, file descriptors)",
+                "Review resource limits and quotas",
+                "Consider scaling infrastructure",
+                "Look for resource leaks or cleanup issues",
+            ],
+            "logic": [
+                "Review code logic for edge cases",
+                "Check assumptions about data state",
+                "Add defensive null checks and bounds validation",
+                "Review recent code changes for regressions",
+            ],
+        }
+
+        suggestions.extend(intervention_map.get(most_common, [
+            "Review error messages and stack traces",
+            "Check recent system or dependency changes",
+            "Consider manual reproduction in isolated environment",
+        ]))
+
+        # Add retry-specific guidance if multiple attempts
+        if len(failed_task.retry_attempts) > 1:
+            suggestions.append(f"Task failed {len(failed_task.retry_attempts)} times - consider if retries are appropriate")
+
+        return suggestions[:5]  # Limit to top 5 suggestions
+
+    def _build_escalation_report(self, failed_task: Task) -> EscalationReport:
+        """Build structured escalation report with diagnostics."""
+        return EscalationReport(
+            task_id=failed_task.id,
+            original_title=failed_task.title,
+            total_attempts=len(failed_task.retry_attempts),
+            attempt_history=failed_task.retry_attempts,
+            root_cause_hypothesis=self._generate_root_cause_hypothesis(failed_task),
+            suggested_interventions=self._generate_suggested_interventions(failed_task),
+            failure_pattern=self._analyze_failure_pattern(failed_task.retry_attempts),
+        )
+
     def create_escalation(self, failed_task: Task, agent_id: str) -> Task:
         """
         Create an escalation task for a failed task.
@@ -104,6 +268,9 @@ class EscalationHandler:
         if self.enable_error_truncation:
             error_msg = self.truncate_error(error_msg)
 
+        # Build structured escalation report
+        escalation_report = self._build_escalation_report(failed_task)
+
         escalation = Task(
             id=escalation_id,
             type=TaskType.ESCALATION,
@@ -113,25 +280,53 @@ class EscalationHandler:
             assigned_to=self.escalation_queue,
             created_at=datetime.utcnow(),
             title=f"ESCALATION: Task failed after {failed_task.retry_count} retries",
-            description=self._build_description(failed_task),
+            description=self._build_description(failed_task, escalation_report),
             failed_task_id=failed_task.id,
             needs_human_review=True,
+            escalation_report=escalation_report,
             context={
                 "original_task_id": failed_task.id,
                 "original_task_type": get_type_str(failed_task.type),
                 "retry_count": failed_task.retry_count,
                 "error": error_msg,
+                "failure_pattern": escalation_report.failure_pattern,
+                "root_cause_hypothesis": escalation_report.root_cause_hypothesis,
             },
         )
 
         return escalation
 
-    def _build_description(self, failed_task: Task) -> str:
-        """Build escalation description."""
-        return (
+    def _build_description(self, failed_task: Task, report: EscalationReport) -> str:
+        """Build escalation description with structured report."""
+        desc = (
             f"Task {failed_task.id} failed after {failed_task.retry_count} retry attempts "
             f"and has been marked as failed. This requires human intervention or product decision.\n\n"
-            f"Original task: {failed_task.title}\n"
-            f"Task type: {get_type_str(failed_task.type)}\n\n"
-            f"Please review the failed task and decide next steps."
+            f"## Original Task\n"
+            f"Title: {failed_task.title}\n"
+            f"Type: {get_type_str(failed_task.type)}\n\n"
         )
+
+        # Add root cause analysis
+        desc += f"## Root Cause Analysis\n"
+        desc += f"**Failure Pattern**: {report.failure_pattern}\n\n"
+        desc += f"**Hypothesis**: {report.root_cause_hypothesis}\n\n"
+
+        # Add attempt history summary
+        if report.attempt_history:
+            desc += f"## Attempt History ({len(report.attempt_history)} attempts)\n"
+            for attempt in report.attempt_history[-3:]:  # Show last 3 attempts
+                desc += f"- **Attempt {attempt.attempt_number}** ({attempt.timestamp.strftime('%Y-%m-%d %H:%M:%S')})\n"
+                desc += f"  Agent: {attempt.agent_id}, Type: {attempt.error_type or 'unknown'}\n"
+                error_preview = attempt.error_message[:100] + "..." if len(attempt.error_message) > 100 else attempt.error_message
+                desc += f"  Error: {error_preview}\n\n"
+
+        # Add suggested interventions
+        desc += f"## Suggested Interventions\n"
+        for i, intervention in enumerate(report.suggested_interventions, 1):
+            desc += f"{i}. {intervention}\n"
+
+        desc += f"\n## Next Steps\n"
+        desc += f"Use `agent guide {failed_task.id} --hint \"<your guidance>\"` to inject human guidance and retry.\n"
+        desc += f"Or review the failed task manually and decide next steps.\n"
+
+        return desc

--- a/tests/unit/test_guided_escalation.py
+++ b/tests/unit/test_guided_escalation.py
@@ -1,0 +1,251 @@
+"""Tests for guided escalation feature with structured reports."""
+
+from datetime import datetime
+
+import pytest
+
+from agent_framework.core.task import Task, TaskStatus, TaskType, RetryAttempt, EscalationReport
+from agent_framework.safeguards.escalation import EscalationHandler
+
+
+def _make_failed_task_with_attempts(**overrides) -> Task:
+    """Create a failed task with retry attempts for testing."""
+    defaults = dict(
+        id="task-123",
+        type=TaskType.IMPLEMENTATION,
+        status=TaskStatus.FAILED,
+        priority=1,
+        created_by="engineer",
+        assigned_to="engineer",
+        created_at=datetime.utcnow(),
+        title="Implement feature X",
+        description="Some description",
+        retry_count=3,
+        last_error="Connection refused: API endpoint not reachable",
+        retry_attempts=[
+            RetryAttempt(
+                attempt_number=1,
+                timestamp=datetime.utcnow(),
+                error_message="Connection refused: API endpoint not reachable",
+                agent_id="engineer",
+                error_type="network",
+            ),
+            RetryAttempt(
+                attempt_number=2,
+                timestamp=datetime.utcnow(),
+                error_message="Connection timeout after 30s",
+                agent_id="engineer",
+                error_type="network",
+            ),
+            RetryAttempt(
+                attempt_number=3,
+                timestamp=datetime.utcnow(),
+                error_message="Network unreachable",
+                agent_id="engineer",
+                error_type="network",
+            ),
+        ],
+    )
+    defaults.update(overrides)
+    return Task(**defaults)
+
+
+class TestEscalationReportGeneration:
+    def test_escalation_includes_structured_report(self):
+        """Escalation should include structured report with diagnostics."""
+        handler = EscalationHandler()
+        task = _make_failed_task_with_attempts()
+        escalation = handler.create_escalation(task, "engineer")
+
+        assert escalation.escalation_report is not None
+        assert escalation.escalation_report.task_id == "task-123"
+        assert escalation.escalation_report.total_attempts == 3
+        assert len(escalation.escalation_report.attempt_history) == 3
+
+    def test_root_cause_hypothesis_generated(self):
+        """Should generate hypothesis about root cause."""
+        handler = EscalationHandler()
+        task = _make_failed_task_with_attempts()
+        escalation = handler.create_escalation(task, "engineer")
+
+        hypothesis = escalation.escalation_report.root_cause_hypothesis
+        assert hypothesis is not None
+        assert len(hypothesis) > 0
+        # Should mention network issues since all attempts had network errors
+        assert "network" in hypothesis.lower()
+
+    def test_suggested_interventions_provided(self):
+        """Should provide actionable intervention suggestions."""
+        handler = EscalationHandler()
+        task = _make_failed_task_with_attempts()
+        escalation = handler.create_escalation(task, "engineer")
+
+        interventions = escalation.escalation_report.suggested_interventions
+        assert len(interventions) > 0
+        # Network errors should suggest network-related interventions
+        assert any("network" in i.lower() or "connectivity" in i.lower() for i in interventions)
+
+    def test_failure_pattern_detection(self):
+        """Should detect failure patterns from retry history."""
+        handler = EscalationHandler()
+        task = _make_failed_task_with_attempts()
+        escalation = handler.create_escalation(task, "engineer")
+
+        pattern = escalation.escalation_report.failure_pattern
+        assert pattern is not None
+        # All network errors = consistent or intermittent_network pattern
+        assert pattern in ["consistent", "intermittent_network"]
+
+    def test_attempt_history_preserved(self):
+        """All retry attempts should be preserved in report."""
+        handler = EscalationHandler()
+        task = _make_failed_task_with_attempts()
+        escalation = handler.create_escalation(task, "engineer")
+
+        attempts = escalation.escalation_report.attempt_history
+        assert len(attempts) == 3
+        assert attempts[0].attempt_number == 1
+        assert attempts[0].error_type == "network"
+        assert attempts[0].agent_id == "engineer"
+
+
+class TestErrorCategorization:
+    def test_network_error_categorization(self):
+        """Should categorize network-related errors."""
+        handler = EscalationHandler()
+        assert handler._categorize_error("Connection refused") == "network"
+        assert handler._categorize_error("Network timeout") == "network"
+        assert handler._categorize_error("Could not resolve host") == "network"
+
+    def test_authentication_error_categorization(self):
+        """Should categorize authentication-related errors."""
+        handler = EscalationHandler()
+        assert handler._categorize_error("Unauthorized: 401") == "authentication"
+        assert handler._categorize_error("Permission denied") == "authentication"
+        assert handler._categorize_error("Invalid credentials") == "authentication"
+
+    def test_validation_error_categorization(self):
+        """Should categorize validation-related errors."""
+        handler = EscalationHandler()
+        assert handler._categorize_error("Validation error: missing field") == "validation"
+        assert handler._categorize_error("Type error: expected int") == "validation"
+        assert handler._categorize_error("Schema mismatch") == "validation"
+
+    def test_unknown_error_fallback(self):
+        """Should return unknown for uncategorized errors."""
+        handler = EscalationHandler()
+        assert handler._categorize_error("Something weird happened") == "unknown"
+
+
+class TestFailurePatternAnalysis:
+    def test_consistent_failure_pattern(self):
+        """Should detect consistent failure pattern."""
+        handler = EscalationHandler()
+        task = _make_failed_task_with_attempts()
+        # All network errors
+        pattern = handler._analyze_failure_pattern(task.retry_attempts)
+        assert pattern in ["consistent", "intermittent_network"]
+
+    def test_varied_failure_pattern(self):
+        """Should detect varied failure pattern."""
+        handler = EscalationHandler()
+        task = _make_failed_task_with_attempts(
+            retry_attempts=[
+                RetryAttempt(
+                    attempt_number=1,
+                    timestamp=datetime.utcnow(),
+                    error_message="Connection refused",
+                    agent_id="engineer",
+                    error_type="network",
+                ),
+                RetryAttempt(
+                    attempt_number=2,
+                    timestamp=datetime.utcnow(),
+                    error_message="Validation error",
+                    agent_id="engineer",
+                    error_type="validation",
+                ),
+                RetryAttempt(
+                    attempt_number=3,
+                    timestamp=datetime.utcnow(),
+                    error_message="Unauthorized",
+                    agent_id="engineer",
+                    error_type="authentication",
+                ),
+            ]
+        )
+        pattern = handler._analyze_failure_pattern(task.retry_attempts)
+        assert pattern == "varied"
+
+
+class TestHumanGuidanceInjection:
+    def test_guidance_added_to_escalation_report(self):
+        """Human guidance should be stored in escalation report."""
+        task = _make_failed_task_with_attempts()
+        report = EscalationReport(
+            task_id=task.id,
+            original_title=task.title,
+            total_attempts=3,
+            attempt_history=task.retry_attempts,
+            root_cause_hypothesis="Network issues",
+            suggested_interventions=["Check network", "Verify endpoints"],
+            human_guidance="Use backup API endpoint: https://backup.api.com",
+        )
+
+        assert report.human_guidance == "Use backup API endpoint: https://backup.api.com"
+
+    def test_task_supports_escalation_report(self):
+        """Task model should support escalation report field."""
+        task = Task(
+            id="test-123",
+            type=TaskType.IMPLEMENTATION,
+            status=TaskStatus.FAILED,
+            priority=1,
+            created_by="engineer",
+            assigned_to="engineer",
+            created_at=datetime.utcnow(),
+            title="Test task",
+            description="Test",
+        )
+
+        # Should be able to attach escalation report
+        task.escalation_report = EscalationReport(
+            task_id=task.id,
+            original_title=task.title,
+            total_attempts=0,
+            attempt_history=[],
+            root_cause_hypothesis="Test hypothesis",
+            suggested_interventions=["Test intervention"],
+            human_guidance="Test guidance",
+        )
+
+        assert task.escalation_report.human_guidance == "Test guidance"
+
+
+class TestDescriptionFormatting:
+    def test_escalation_description_includes_report(self):
+        """Escalation description should include formatted report."""
+        handler = EscalationHandler()
+        task = _make_failed_task_with_attempts()
+        escalation = handler.create_escalation(task, "engineer")
+
+        description = escalation.description
+
+        # Should include key sections
+        assert "Root Cause Analysis" in description
+        assert "Attempt History" in description
+        assert "Suggested Interventions" in description
+        assert "agent guide" in description  # Should mention guide command
+
+    def test_description_includes_attempt_details(self):
+        """Description should show attempt history details."""
+        handler = EscalationHandler()
+        task = _make_failed_task_with_attempts()
+        escalation = handler.create_escalation(task, "engineer")
+
+        description = escalation.description
+
+        # Should show attempt numbers
+        assert "Attempt 1" in description or "attempt 1" in description
+        # Should show error types
+        assert "network" in description.lower()


### PR DESCRIPTION
## Summary

- Add structured escalation reports with error categorization, failure pattern detection, and AI-generated root cause hypothesis
- Add `agent guide <task-id> --hint "<guidance>"` CLI command to inject expert guidance into failed tasks for retry
- Integrate human guidance and previous failure context into LLM prompts automatically

## Changes

- **Task model**: `RetryAttempt`, `EscalationReport` models with error categorization
- **EscalationHandler**: Structured report generation with pattern analysis
- **Agent**: `_inject_human_guidance()` and `_categorize_error()` helpers
- **CLI**: `agent guide` command for human-in-the-loop intervention

## Test plan

- [ ] 15 new tests in `test_guided_escalation.py` pass
- [ ] Existing tests unaffected (backward compatible)
- [ ] Manual test: `agent guide <task-id> --hint "try X"` injects guidance and re-queues

🤖 Generated with [Claude Code](https://claude.com/claude-code)