### PR TITLE
Extend model routing with specialization signals

### DIFF
--- a/src/agent_framework/core/agent.py
+++ b/src/agent_framework/core/agent.py
@@ -251,6 +251,7 @@ class Agent:
         self._workflow_team_cache: Dict[str, Optional[dict]] = {}
         # Set per-task by _build_prompt, consumed by team composition
         self._current_specialization = None
+        self._current_file_count = 0
 
         # Pause signal cache (avoid 2x exists() calls every 2s)
         self._pause_signal_cache: Optional[bool] = None
@@ -865,6 +866,8 @@ class Agent:
                     context=task.context,
                     working_dir=str(working_dir),
                     agents=team_agents,
+                    specialization_profile=self._current_specialization.id if self._current_specialization else None,
+                    file_count=self._current_file_count,
                 ),
                 task_id=task.id,
                 on_tool_activity=_on_tool_activity,
@@ -1926,9 +1929,12 @@ Fix the failing tests and ensure all tests pass.
         use_optimizations = self._should_use_optimization(task)
 
         # Detect specialization once — reused for both prompt and team composition
-        from .engineer_specialization import apply_specialization_to_prompt
+        from .engineer_specialization import apply_specialization_to_prompt, detect_file_patterns
         profile = self._detect_engineer_specialization(task)
         self._current_specialization = profile
+        # Extract file count for model routing (specialization-aware routing uses this)
+        files = detect_file_patterns(task)
+        self._current_file_count = len(files)
         prompt_text = apply_specialization_to_prompt(self.config.prompt, profile)
 
         # Update activity with specialization (if detected)

--- a/src/agent_framework/llm/claude_cli_backend.py
+++ b/src/agent_framework/llm/claude_cli_backend.py
@@ -217,7 +217,12 @@ class ClaudeCLIBackend(LLMBackend):
         if request.model:
             model = request.model
         elif request.task_type:
-            model = self.select_model(request.task_type, request.retry_count)
+            model = self.select_model(
+                request.task_type,
+                request.retry_count,
+                request.specialization_profile,
+                request.file_count,
+            )
         else:
             model = self.model_selector.default_model
 
@@ -559,9 +564,20 @@ class ClaudeCLIBackend(LLMBackend):
             except ProcessLookupError:
                 pass
 
-    def select_model(self, task_type: TaskType, retry_count: int) -> str:
-        """Select appropriate model based on task type and retry count."""
-        return self.model_selector.select(task_type, retry_count)
+    def select_model(
+        self,
+        task_type: TaskType,
+        retry_count: int,
+        specialization_profile: str = None,
+        file_count: int = 0,
+    ) -> str:
+        """Select appropriate model based on task type, retry count, and specialization."""
+        return self.model_selector.select(
+            task_type,
+            retry_count,
+            specialization_profile,
+            file_count,
+        )
 
     def _expand_mcp_config(self, config_path: Path) -> Path:
         """Expand environment variables in MCP config and write to process-specific temp file."""

--- a/src/agent_framework/llm/litellm_backend.py
+++ b/src/agent_framework/llm/litellm_backend.py
@@ -74,7 +74,12 @@ class LiteLLMBackend(LLMBackend):
         if request.model:
             model = request.model
         elif request.task_type:
-            model = self.select_model(request.task_type, request.retry_count)
+            model = self.select_model(
+                request.task_type,
+                request.retry_count,
+                request.specialization_profile,
+                request.file_count,
+            )
         else:
             model = self.model_selector.default_model
 
@@ -182,6 +187,17 @@ class LiteLLMBackend(LLMBackend):
             if log_file:
                 log_file.close()
 
-    def select_model(self, task_type: TaskType, retry_count: int) -> str:
-        """Select appropriate model based on task type and retry count."""
-        return self.model_selector.select(task_type, retry_count)
+    def select_model(
+        self,
+        task_type: TaskType,
+        retry_count: int,
+        specialization_profile: str = None,
+        file_count: int = 0,
+    ) -> str:
+        """Select appropriate model based on task type, retry count, and specialization."""
+        return self.model_selector.select(
+            task_type,
+            retry_count,
+            specialization_profile,
+            file_count,
+        )


### PR DESCRIPTION
## Summary

Extends `ModelSelector` to use specialization profile and file count as routing signals for implementation tasks. Frontend tasks with few files get routed to the cheap model (Haiku), while backend/infrastructure tasks with many files get routed to the premium model (Opus). Existing retry escalation takes priority.

## Changes

- **`llm/model_selector.py`** — Added `specialization_profile` and `file_count` params to `select()` with priority-based routing: retry escalation > fixed premium/cheap > specialization-aware > default
- **`llm/base.py`** — Extended `LLMRequest` with `specialization_profile` and `file_count` fields
- **`llm/claude_cli_backend.py` / `llm/litellm_backend.py`** — Forward specialization signals through `select_model()` to `ModelSelector`
- **`core/agent.py`** — Passes specialization ID and file count from `_detect_engineer_specialization()` into `LLMRequest`
- **`tests/unit/test_model_selector.py`** — 9 new tests for specialization routing covering all routing paths and priority ordering

## Routing Rules

| Specialization | File Count | Model |
|---|---|---|
| backend / infrastructure | >= 8 | Premium (Opus) |
| frontend | <= 5 | Cheap (Haiku) |
| Any other combination | - | Default (Sonnet) |

Retry escalation (retry_count >= 3) always overrides specialization routing.

## Change Metrics

- **6 files changed**, 199 insertions, 23 deletions
- **29 total tests** in model selector (9 new specialization routing tests)
- **832 tests pass** across the full suite

## Test Plan

- [x] All 9 specialization routing tests pass
- [x] All 20 existing model selector tests pass
- [x] Full test suite (832 tests) passes
- [x] Rebased onto main to preserve recent `use_max_account` and `CLAUDECODE` fixes