### PR TITLE
Fix Pydantic V2 deprecation: migrate json_encoders to field_serializer

### DIFF
--- a/src/agent_framework/core/task.py
+++ b/src/agent_framework/core/task.py
@@ -3,7 +3,7 @@
 from datetime import UTC, datetime
 from enum import Enum
 from typing import Any, Optional, List
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 
 class RetryAttempt(BaseModel):
@@ -163,12 +163,14 @@ class Task(BaseModel):
     parent_task_id: Optional[str] = None
     subtask_ids: list[str] = Field(default_factory=list)
 
-    class Config:
-        """Pydantic config."""
-        use_enum_values = True
-        json_encoders = {
-            datetime: lambda v: v.isoformat() if v else None
-        }
+    model_config = ConfigDict(use_enum_values=True)
+
+    @field_serializer(
+        "created_at", "last_failed_at", "started_at",
+        "completed_at", "failed_at", "approved_at",
+    )
+    def serialize_datetime(self, v: Optional[datetime], _info) -> Optional[str]:
+        return v.isoformat() if v else None
 
     def mark_in_progress(self, agent_id: str) -> None:
         """Mark task as in progress."""


### PR DESCRIPTION
## Summary
- Replace deprecated `class Config: json_encoders` with `@field_serializer` decorator on Task model
- Migrate class-based `Config` to `model_config = ConfigDict(use_enum_values=True)`
- Covers all 6 datetime fields: `created_at`, `last_failed_at`, `started_at`, `completed_at`, `failed_at`, `approved_at`

## Why
`json_encoders` emits a `PydanticDeprecatedSince20` warning on every import. Pydantic V3 will remove it entirely, making this a hard blocker for upgrades.

## Risk: LOW
- Single file changed (`src/agent_framework/core/task.py`), 9 insertions / 7 deletions
- Pydantic V2 natively serializes `datetime` → ISO 8601, so output is identical
- All 16 existing tests pass (test_task.py + test_plan_document.py)

## Test plan
- [x] `pytest tests/unit/test_task.py` — 7/7 passed
- [x] `pytest tests/unit/test_plan_document.py` — 9/9 passed
- [x] JSON round-trip test confirms serialization/deserialization unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)